### PR TITLE
fix(inputs): use non-remappable mapping

### DIFF
--- a/lua/searchbox/inputs.lua
+++ b/lua/searchbox/inputs.lua
@@ -103,7 +103,7 @@ M.default_mappings = function(input, winid)
   end
 
   local win_exe = function(cmd)
-    vim.fn.win_execute(winid, string.format('exe "normal %s"', cmd))
+    vim.fn.win_execute(winid, string.format('exe "normal! %s"', cmd))
   end
 
   map('<C-c>', input.input_props.on_close)


### PR DESCRIPTION
I mapped `<C-e>` and `<C-y>` in normal mode and want to use the origin behavior of the mappings in search box