### PR TITLE
fix: go normal mode before getting visual text range

### DIFF
--- a/lua/searchbox/inputs.lua
+++ b/lua/searchbox/inputs.lua
@@ -35,6 +35,8 @@ M.search = function(config, search_opts, handlers)
   state.current_cursor = state.start_cursor
 
   if search_opts.visual_mode then
+    -- always go nomal mode before getting visual text range
+    vim.cmd([[ execute "normal! \<ESC>" ]])
     state.range = {
       start = {vim.fn.line("'<"), vim.fn.col("'<")},
       ends = {vim.fn.line("'>"), vim.fn.col("'>")},


### PR DESCRIPTION
When you open a file and enter line/block visual mode instead of normal visual at the first time, do the search/replace in the selected range would not popup the searchbox, it would say "Could not find any text selected." since the `vim.fn.line("'<")` always returns 0, the solution fot this is alway go back to normal mode before use the `line()` function for selected range.
https://github.com/neovim/neovim/discussions/26092#discussioncomment-7604883